### PR TITLE
feat: update Shadow AI logo and app theme

### DIFF
--- a/app/[locale]/[workspaceid]/page.tsx
+++ b/app/[locale]/[workspaceid]/page.tsx
@@ -197,7 +197,7 @@ export default function WorkspacePage() {
         {/* Quick start */}
         <Card className="mb-7 grid grid-cols-[auto_1fr_auto] items-center gap-[18px] p-5">
           <div className="bg-ink flex size-11 items-center justify-center rounded-xl">
-            <ShadowAISVG scale={22 / 24} />
+            <ShadowAISVG scale={22 / 64} />
           </div>
           <div>
             <div className="text-ink mb-0.5 text-[14px] font-semibold">

--- a/app/[locale]/globals.css
+++ b/app/[locale]/globals.css
@@ -3,50 +3,50 @@
 @tailwind utilities;
 
 /* ============================================================
-   Shadow AI — Scientific-editorial design tokens
-   Palette: warm paper neutrals + rust accent
+   Shadow AI — Neon biotech design tokens
+   Palette: deep indigo + cyan/blue glow + violet accent
    Type: Inter Tight (UI) · Instrument Serif (display) · JetBrains Mono
    ============================================================ */
 
 @layer base {
   :root {
-    /* ----- Editorial raw tokens (direct use) ----- */
-    --paper: #faf8f5;
-    --paper-2: #f3efe9;
-    --paper-3: #e9e3db;
-    --line: #e3ddd3;
-    --line-strong: #cfc6b8;
-    --ink: #1a1714;
-    --ink-2: #3d3732;
-    --ink-3: #6b635a;
-    --ink-4: #938a7e;
+    /* ----- Brand raw tokens (direct use) ----- */
+    --paper: #f3f7ff;
+    --paper-2: #dce5ff;
+    --paper-3: #c0cdf8;
+    --line: #c7d4ff;
+    --line-strong: #96a8e8;
+    --ink: #08122f;
+    --ink-2: #19305d;
+    --ink-3: #546898;
+    --ink-4: #7c86b6;
     --surface: #ffffff;
 
-    --rust: #b25139;
-    --rust-hover: #9f4530;
-    --rust-soft: #f6e8e1;
-    --rust-ink: #5c2b1c;
+    --rust: #12e3f0;
+    --rust-hover: #09c9dc;
+    --rust-soft: #dffcff;
+    --rust-ink: #063744;
 
-    /* Phase tints — used sparingly, only on stage identity */
-    --p-overview: #7a8471;
-    --p-problem: #2f6b6b;
-    --p-lit: #b25139;
-    --p-hyp: #6b5ba8;
-    --p-design: #8b6f2b;
+    /* Phase tints — tuned to the logo palette */
+    --p-overview: #3aa8ff;
+    --p-problem: #12e3f0;
+    --p-lit: #5c7dff;
+    --p-hyp: #c98bff;
+    --p-design: #7b5dff;
 
-    --success: #3f7a4e;
-    --warn: #b8831f;
-    --danger: #a1422e;
-    --info: #2f6b6b;
+    --success: #22c55e;
+    --warn: #f59e0b;
+    --danger: #ef4444;
+    --info: #3aa8ff;
 
     /* Shadows */
-    --shadow-sm: 0 1px 2px rgba(26, 23, 20, 0.04),
-      0 1px 3px rgba(26, 23, 20, 0.03);
-    --shadow-md: 0 2px 4px rgba(26, 23, 20, 0.04),
-      0 8px 24px rgba(26, 23, 20, 0.06);
-    --shadow-lg: 0 8px 16px rgba(26, 23, 20, 0.06),
-      0 24px 56px rgba(26, 23, 20, 0.1);
-    --shadow-drawer: -24px 0 56px rgba(26, 23, 20, 0.12);
+    --shadow-sm: 0 1px 2px rgba(11, 2, 64, 0.10),
+      0 1px 3px rgba(11, 2, 64, 0.08);
+    --shadow-md: 0 6px 18px rgba(11, 2, 64, 0.12),
+      0 10px 28px rgba(17, 14, 83, 0.10);
+    --shadow-lg: 0 14px 36px rgba(11, 2, 64, 0.16),
+      0 24px 56px rgba(17, 14, 83, 0.16);
+    --shadow-drawer: -24px 0 56px rgba(11, 2, 64, 0.18);
 
     /* Radii */
     --r-sm: 6px;
@@ -64,136 +64,134 @@
     --f-display: var(--font-instrument-serif), Georgia, serif;
     --f-mono: var(--font-jetbrains-mono), ui-monospace, "SF Mono", monospace;
 
-    /* ----- shadcn HSL tokens (remapped to editorial palette) ----- */
+    /* ----- shadcn HSL tokens remapped to the logo palette ----- */
     /* Values are "H S% L%" triplets, consumed via hsl(var(--xxx)) */
-    --background: 36 33% 97%; /* paper */
-    --foreground: 25 12% 9%; /* ink */
+    --background: 225 100% 98%;
+    --foreground: 223 71% 11%;
 
-    --surface-hsl: 0 0% 100%; /* surface */
-    --paper-hsl: 36 33% 97%;
-    --paper-2-hsl: 34 29% 93%;
-    --paper-3-hsl: 33 25% 89%;
-    --line-hsl: 35 27% 86%;
-    --line-strong-hsl: 37 20% 77%;
-    --ink-hsl: 25 12% 9%;
-    --ink-2-hsl: 27 9% 22%;
-    --ink-3-hsl: 30 9% 39%;
-    --ink-4-hsl: 29 10% 54%;
-    --rust-hsl: 13 53% 46%;
-    --rust-soft-hsl: 20 57% 93%;
-    --rust-ink-hsl: 15 53% 24%;
+    --surface-hsl: 0 0% 100%;
+    --paper-hsl: 225 100% 98%;
+    --paper-2-hsl: 222 100% 93%;
+    --paper-3-hsl: 226 78% 87%;
+    --line-hsl: 223 100% 89%;
+    --line-strong-hsl: 227 64% 75%;
+    --ink-hsl: 223 71% 11%;
+    --ink-2-hsl: 220 58% 23%;
+    --ink-3-hsl: 224 29% 46%;
+    --ink-4-hsl: 231 29% 60%;
+    --rust-hsl: 184 89% 51%;
+    --rust-soft-hsl: 185 100% 94%;
+    --rust-ink-hsl: 193 84% 15%;
 
-    --muted: 34 29% 93%; /* paper-2 */
-    --muted-foreground: 30 9% 39%; /* ink-3 */
+    --muted: 222 100% 93%;
+    --muted-foreground: 224 29% 46%;
 
-    --popover: 0 0% 100%; /* surface */
-    --popover-foreground: 25 12% 9%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 223 71% 11%;
 
-    --card: 0 0% 100%; /* surface */
-    --card-foreground: 25 12% 9%;
+    --card: 0 0% 100%;
+    --card-foreground: 223 71% 11%;
 
-    --border: 35 27% 86%; /* line */
-    --input: 35 27% 86%;
+    --border: 223 100% 89%;
+    --input: 223 100% 89%;
 
-    /* Primary (neutral ink on paper) — used by default shadcn buttons */
-    --primary: 25 12% 9%;
-    --primary-foreground: 36 33% 97%;
+    /* Primary follows the bright cyan logo highlight */
+    --primary: 184 89% 51%;
+    --primary-foreground: 223 71% 11%;
 
-    /* Secondary (muted paper bg) */
-    --secondary: 34 29% 93%;
-    --secondary-foreground: 25 12% 9%;
+    /* Secondary uses the electric blue from the wordmark */
+    --secondary: 207 100% 61%;
+    --secondary-foreground: 0 0% 100%;
 
-    /* shadcn "accent" is a subtle hover surface, NOT the brand rust.
-       Use --rust / bg-rust utilities for brand accent. */
-    --accent: 34 29% 93%;
-    --accent-foreground: 25 12% 9%;
+    /* Accent uses the violet highlight from the helix */
+    --accent: 275 100% 77%;
+    --accent-foreground: 223 71% 11%;
 
-    --destructive: 12 56% 40%;
-    --destructive-foreground: 36 33% 97%;
+    --destructive: 0 84% 60%;
+    --destructive-foreground: 0 0% 100%;
 
-    --ring: 13 53% 46%; /* rust focus ring */
+    --ring: 184 89% 51%;
 
     --radius: 0.625rem; /* 10px — editorial r-md */
   }
 
   .dark {
-    /* Dark mode: warm near-black paper + warm ink-on-dark text.
-       Rust accent is kept but softened. */
-    --paper: #17140f;
-    --paper-2: #1f1b16;
-    --paper-3: #2a251f;
-    --line: #33302a;
-    --line-strong: #4a4540;
-    --ink: #f3efe9;
-    --ink-2: #cfc6b8;
-    --ink-3: #938a7e;
-    --ink-4: #6b635a;
-    --surface: #1a1714;
+    /* Dark mode is the primary brand surface for this logo. */
+    --paper: #0b0240;
+    --paper-2: #120a52;
+    --paper-3: #1b1468;
+    --line: #24306b;
+    --line-strong: #3a4f99;
+    --ink: #f3f7ff;
+    --ink-2: #dce5ff;
+    --ink-3: #aebcf3;
+    --ink-4: #7c86b6;
+    --surface: #120a52;
 
-    --rust: #c5694f;
-    --rust-hover: #d37d64;
-    --rust-soft: #3a1c13;
-    --rust-ink: #f6e8e1;
+    --rust: #12e3f0;
+    --rust-hover: #5deef6;
+    --rust-soft: #112a58;
+    --rust-ink: #dffcff;
 
-    /* Phase tints — brightened for legibility on dark ink. */
-    --p-overview: #9cab93;
-    --p-problem: #4fa0a0;
-    --p-lit: #c5694f;
-    --p-hyp: #9285c6;
-    --p-design: #c09a4f;
+    /* Phase tints — bright neon variants for dark UI. */
+    --p-overview: #3aa8ff;
+    --p-problem: #12e3f0;
+    --p-lit: #6d7cff;
+    --p-hyp: #c98bff;
+    --p-design: #8c63ff;
 
-    --success: #5fa06d;
-    --warn: #d6a333;
-    --danger: #c05a44;
-    --info: #4fa0a0;
+    --success: #4ade80;
+    --warn: #fbbf24;
+    --danger: #f87171;
+    --info: #38bdf8;
 
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4), 0 1px 3px rgba(0, 0, 0, 0.3);
-    --shadow-md: 0 2px 4px rgba(0, 0, 0, 0.4), 0 8px 24px rgba(0, 0, 0, 0.5);
-    --shadow-lg: 0 8px 16px rgba(0, 0, 0, 0.5), 0 24px 56px rgba(0, 0, 0, 0.6);
-    --shadow-drawer: -24px 0 56px rgba(0, 0, 0, 0.5);
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.45), 0 1px 3px rgba(0, 0, 0, 0.3);
+    --shadow-md: 0 10px 28px rgba(0, 0, 0, 0.36), 0 14px 36px rgba(11, 2, 64, 0.32);
+    --shadow-lg: 0 18px 48px rgba(0, 0, 0, 0.42), 0 24px 64px rgba(11, 2, 64, 0.36);
+    --shadow-drawer: -24px 0 56px rgba(0, 0, 0, 0.45);
 
-    --background: 30 21% 8%;
-    --foreground: 34 29% 93%;
+    --background: 248 88% 13%;
+    --foreground: 225 100% 98%;
 
-    --surface-hsl: 25 12% 9%;
-    --paper-hsl: 30 21% 8%;
-    --paper-2-hsl: 30 17% 11%;
-    --paper-3-hsl: 29 15% 15%;
-    --line-hsl: 30 9% 18%;
-    --line-strong-hsl: 28 7% 27%;
-    --ink-hsl: 34 29% 93%;
-    --ink-2-hsl: 37 20% 77%;
-    --ink-3-hsl: 29 10% 54%;
-    --ink-4-hsl: 30 9% 39%;
-    --rust-hsl: 13 50% 54%;
-    --rust-soft-hsl: 15 53% 16%;
-    --rust-ink-hsl: 20 57% 93%;
+    --surface-hsl: 248 78% 18%;
+    --paper-hsl: 248 88% 13%;
+    --paper-2-hsl: 248 78% 18%;
+    --paper-3-hsl: 246 68% 24%;
+    --line-hsl: 228 48% 28%;
+    --line-strong-hsl: 227 45% 41%;
+    --ink-hsl: 225 100% 98%;
+    --ink-2-hsl: 222 100% 93%;
+    --ink-3-hsl: 225 71% 81%;
+    --ink-4-hsl: 231 29% 60%;
+    --rust-hsl: 184 89% 51%;
+    --rust-soft-hsl: 221 67% 21%;
+    --rust-ink-hsl: 185 100% 94%;
 
-    --muted: 30 17% 11%;
-    --muted-foreground: 29 10% 54%;
+    --muted: 248 58% 20%;
+    --muted-foreground: 225 40% 74%;
 
-    --popover: 25 12% 9%;
-    --popover-foreground: 34 29% 93%;
+    --popover: 248 78% 18%;
+    --popover-foreground: 225 100% 98%;
 
-    --card: 25 12% 9%;
-    --card-foreground: 34 29% 93%;
+    --card: 248 78% 18%;
+    --card-foreground: 225 100% 98%;
 
-    --border: 30 9% 18%;
-    --input: 30 9% 18%;
+    --border: 228 48% 28%;
+    --input: 228 48% 28%;
 
-    --primary: 34 29% 93%;
-    --primary-foreground: 25 12% 9%;
+    --primary: 184 89% 51%;
+    --primary-foreground: 223 71% 11%;
 
-    --secondary: 30 17% 11%;
-    --secondary-foreground: 34 29% 93%;
+    --secondary: 207 100% 61%;
+    --secondary-foreground: 0 0% 100%;
 
-    --accent: 30 17% 11%;
-    --accent-foreground: 34 29% 93%;
+    --accent: 275 100% 77%;
+    --accent-foreground: 223 71% 11%;
 
-    --destructive: 12 56% 50%;
-    --destructive-foreground: 34 29% 93%;
+    --destructive: 0 84% 65%;
+    --destructive-foreground: 0 0% 100%;
 
-    --ring: 13 50% 54%;
+    --ring: 184 89% 51%;
   }
 }
 
@@ -216,7 +214,7 @@
 
   ::selection {
     background: var(--rust);
-    color: var(--paper);
+    color: var(--ink);
   }
 
   :focus-visible {

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -76,7 +76,7 @@ export const metadata: Metadata = {
 }
 
 export const viewport: Viewport = {
-  themeColor: "#000000"
+  themeColor: "#0b0240"
 }
 
 const i18nNamespaces = ["translation"]
@@ -116,7 +116,7 @@ export default async function RootLayout({
       className={`${interTight.variable} ${instrumentSerif.variable} ${jetbrainsMono.variable}`}
     >
       <body className="font-sans">
-        <Providers attribute="class" defaultTheme="light">
+        <Providers attribute="class" defaultTheme="dark">
           <TranslationsProvider
             namespaces={i18nNamespaces}
             locale={locale}

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -9,7 +9,7 @@ export default function HomePage() {
   return (
     <div className="bg-paper flex size-full flex-col items-center justify-center px-6">
       <div className="flex max-w-[720px] flex-col items-center gap-7">
-        <ShadowAISVG scale={2.5} />
+        <ShadowAISVG scale={1.1} />
         <div className="flex flex-col items-center gap-4">
           <h1 className="font-display text-ink text-balance text-center text-[36px] font-normal leading-[1.05] tracking-[-0.02em] sm:text-[44px] md:text-[56px]">
             <span className="text-rust">Shadow AI</span>, your AI co-scientist

--- a/components/agent/agent-drawer.tsx
+++ b/components/agent/agent-drawer.tsx
@@ -72,7 +72,7 @@ export function AgentDrawer({
         <div className="border-line flex flex-col gap-2 border-b p-4 pb-3">
           <div className="flex items-center gap-2.5">
             <div className="bg-ink flex size-7 items-center justify-center rounded-md">
-              <ShadowAISVG scale={16 / 24} />
+              <ShadowAISVG scale={16 / 64} />
             </div>
             <div className="min-w-0 flex-1">
               <div className="text-ink text-[13px] font-semibold">

--- a/components/design-flow/agent-running-card.tsx
+++ b/components/design-flow/agent-running-card.tsx
@@ -45,7 +45,7 @@ export function AgentRunningCard({
     >
       <div className="mb-3.5 flex items-center gap-3">
         <div className="bg-ink relative flex size-9 items-center justify-center rounded-md">
-          <ShadowAISVG scale={18 / 24} />
+          <ShadowAISVG scale={18 / 64} />
           <span
             className="border-rust absolute -inset-[3px] animate-spin rounded-md border-[1.5px]"
             style={{

--- a/components/icons/chatbotui-svg.tsx
+++ b/components/icons/chatbotui-svg.tsx
@@ -1,29 +1,63 @@
 import { FC } from "react"
 
 interface ShadowAISVGProps {
-  /** Retained for API compatibility; the editorial monogram is theme-agnostic
-   *  and uses ink + rust tokens from CSS. */
   theme?: "dark" | "light"
   scale?: number
 }
 
-/**
- * Editorial monogram: a solid ink disc with a rust half-crescent on the
- * right half — a "shadow" cast across the moon. Theme-agnostic.
- */
 export const ShadowAISVG: FC<ShadowAISVGProps> = ({ scale = 1 }) => {
   const size = 24 * scale
+
   return (
     <svg
       width={size}
       height={size}
-      viewBox="0 0 24 24"
+      viewBox="0 0 64 64"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       aria-hidden
     >
-      <circle cx="12" cy="12" r="10" fill="hsl(var(--ink-hsl))" />
-      <path d="M12 2a10 10 0 0 0 0 20V2z" fill="hsl(var(--rust-hsl))" />
+      <defs>
+        <linearGradient id="shadowai-helix-gradient" x1="10" y1="8" x2="54" y2="56" gradientUnits="userSpaceOnUse">
+          <stop offset="0" stopColor="#12E3F0" />
+          <stop offset="0.55" stopColor="#3AA8FF" />
+          <stop offset="1" stopColor="#C98BFF" />
+        </linearGradient>
+        <linearGradient id="shadowai-node-gradient" x1="20" y1="14" x2="46" y2="50" gradientUnits="userSpaceOnUse">
+          <stop offset="0" stopColor="#A4F5FF" />
+          <stop offset="1" stopColor="#DDB5FF" />
+        </linearGradient>
+      </defs>
+
+      <path
+        d="M22 9C31 9 42 15 42 25C42 31.5 35.5 36 29 40.5C22.8 44.8 17 49 17 55"
+        stroke="url(#shadowai-helix-gradient)"
+        strokeWidth="4.5"
+        strokeLinecap="round"
+      />
+      <path
+        d="M42 9C33 9 22 15 22 25C22 31.5 28.5 36 35 40.5C41.2 44.8 47 49 47 55"
+        stroke="url(#shadowai-helix-gradient)"
+        strokeWidth="4.5"
+        strokeLinecap="round"
+      />
+
+      <path d="M24 14H40" stroke="#6FD7FF" strokeWidth="2.2" strokeLinecap="round" opacity="0.95" />
+      <path d="M21 24H43" stroke="#56C0FF" strokeWidth="2.2" strokeLinecap="round" opacity="0.95" />
+      <path d="M22 34H42" stroke="#49B2FF" strokeWidth="2.2" strokeLinecap="round" opacity="0.92" />
+      <path d="M25 44H39" stroke="#7BBAFF" strokeWidth="2.2" strokeLinecap="round" opacity="0.9" />
+      <path d="M28 52H36" stroke="#B89CFF" strokeWidth="2.2" strokeLinecap="round" opacity="0.88" />
+
+      <circle cx="24" cy="14" r="2.7" fill="url(#shadowai-node-gradient)" />
+      <circle cx="40" cy="14" r="2.7" fill="url(#shadowai-node-gradient)" />
+      <circle cx="21" cy="24" r="2.7" fill="url(#shadowai-node-gradient)" />
+      <circle cx="43" cy="24" r="2.7" fill="url(#shadowai-node-gradient)" />
+      <circle cx="22" cy="34" r="2.7" fill="url(#shadowai-node-gradient)" />
+      <circle cx="42" cy="34" r="2.7" fill="url(#shadowai-node-gradient)" />
+      <circle cx="25" cy="44" r="2.7" fill="url(#shadowai-node-gradient)" />
+      <circle cx="39" cy="44" r="2.7" fill="url(#shadowai-node-gradient)" />
+      <circle cx="28" cy="52" r="2.7" fill="url(#shadowai-node-gradient)" />
+      <circle cx="36" cy="52" r="2.7" fill="url(#shadowai-node-gradient)" />
     </svg>
   )
 }

--- a/components/ui/brand.tsx
+++ b/components/ui/brand.tsx
@@ -6,17 +6,12 @@ import { ShadowAISVG } from "@/components/icons/chatbotui-svg"
 import { cn } from "@/lib/utils"
 
 interface BrandProps {
-  /** Retained for API compatibility; the editorial brand is theme-agnostic. */
   theme?: "dark" | "light"
   size?: number
   collapsed?: boolean
   className?: string
 }
 
-/**
- * Editorial brand lockup: half-moon monogram + "Shadow." wordmark in
- * Instrument Serif, with a rust period.
- */
 export const Brand: FC<BrandProps> = ({
   size = 22,
   collapsed = false,
@@ -24,10 +19,13 @@ export const Brand: FC<BrandProps> = ({
 }) => {
   return (
     <div className={cn("flex items-center gap-2.5", className)}>
-      <ShadowAISVG scale={size / 24} />
+      <ShadowAISVG scale={size / 64} />
       {!collapsed && (
-        <span className="font-display text-ink pt-0.5 text-[22px] leading-none tracking-[-0.01em]">
-          Shadow <span className="text-rust">AI</span>
+        <span className="pt-0.5 text-[22px] font-semibold leading-none tracking-[-0.02em] text-foreground">
+          <span className="text-primary">Shadow</span>{" "}
+          <span className="bg-[linear-gradient(90deg,#3AA8FF_0%,#C98BFF_100%)] bg-clip-text text-transparent">
+            AI
+          </span>
         </span>
       )}
     </div>


### PR DESCRIPTION
## Summary
- replace the app logo with the new neon DNA-style Shadow AI mark
- update the app brand colors to match the logo palette
- default the app to the dark brand theme for better logo contrast

## Validation
- lint could not be run in this environment because Next.js dependencies are not installed locally
